### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Vapi TypeScript library provides convenient access to the Vapi API from Type
 ## Installation
 
 ```sh
-npm i -s @vapi-ai/server-sdk
+npm i @vapi-ai/server-sdk
 ```
 
 ## Usage


### PR DESCRIPTION
the -s doesn't make the downloading of the development work, it was until I removed it, then I was able to download the vapi server sdk